### PR TITLE
Update homepage h1 mobile styling to match design

### DIFF
--- a/src/components/UI/homepage/HomeHero.tsx
+++ b/src/components/UI/homepage/HomeHero.tsx
@@ -19,9 +19,9 @@ export const HomeHero: FC = () => {
           textStyle='h1'
           mb={{ base: 2, md: 4 }}
           textAlign={{ base: 'center', md: 'left' }}
-          fontSize={{ base: '5xl', md: '8xl' }}
-          lineHeight={{ md: '6rem' }}
-          fontWeight='500'
+          fontSize={{ base: '2.75rem', md: '8xl' }}
+          lineHeight={{ base: '3.375rem', md: '6rem' }}
+          fontWeight={{ base: 700, md: 500 }}
         >
           go-ethereum
         </Box>


### PR DESCRIPTION
Adjusts mobile styling of the homepage h1 in `HomeHero` to match figma

<img width="401" alt="image" src="https://user-images.githubusercontent.com/54227730/204395296-fc2fb4bc-bfde-4c50-94ee-2f534401fa21.png">
