### PR TITLE
Patch responsive width [Fixes #53]

### DIFF
--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export const Layout: FC<Props> = ({ children }) => {
   return (
-    <Container maxW={{ base: 'container.sm', md: 'container.2xl' }} my={{ base: 4, md: 7 }}>
+    <Container maxW={{ base: 'full', md: 'container.2xl' }} my={{ base: 4, md: 7 }}>
       <Header />
 
       {children}


### PR DESCRIPTION
## Description
- Remove max-width of `container.sm` on mobile screen sizes, replacing with 100%.
- Leaves existing max-width for desktop sizes.

## Screensshot
<img width="755" alt="image" src="https://user-images.githubusercontent.com/54227730/205211420-d08fcbd1-3a38-4ca3-ae06-9d9715856523.png">

## Related issue
- [Fixes #53]