### PR TITLE
Remove any margin on first markdown item [Fixes #75]

### DIFF
--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -116,7 +116,7 @@ const DocPage: NextPage<Props> = ({ frontmatter, content, navLinks, lastModified
             </Stack>
 
             <Flex width='100%' placeContent='space-between'>
-              <Stack maxW='768px'>
+              <Stack maxW='768px' sx={{ "*:first-child": { marginTop: '0 !important' } }}>
                 <ReactMarkdown
                   remarkPlugins={[gfm]}
                   rehypePlugins={[rehypeRaw]}


### PR DESCRIPTION
## Description
- Removes any extra top margin on the first item shown in markdown content

## Related issue
- [Fixes #75]