### PR TITLE
Add gap between md content and right nav [Fixes #77]

### DIFF
--- a/src/components/UI/docs/DocumentNav.tsx
+++ b/src/components/UI/docs/DocumentNav.tsx
@@ -24,7 +24,7 @@ export const DocumentNav: FC<Props> = ({ content }) => {
       <Text as='h5' textStyle='document-nav-title'>
         on this page
       </Text>
-      <Divider borderColor='primary' my={`4 !important`} w="70%" />
+      <Divider borderColor='primary' my={`4 !important`} />
       {parsedHeadings.map((heading, idx) => {
         return (
           <NextLink key={`${idx} ${heading?.title}`} href={`#${heading?.headingId}`}>

--- a/src/components/UI/docs/DocumentNav.tsx
+++ b/src/components/UI/docs/DocumentNav.tsx
@@ -24,7 +24,7 @@ export const DocumentNav: FC<Props> = ({ content }) => {
       <Text as='h5' textStyle='document-nav-title'>
         on this page
       </Text>
-      <Divider borderColor='primary' my={`4 !important`} />
+      <Divider borderColor='primary' my={`4 !important`} w="70%" />
       {parsedHeadings.map((heading, idx) => {
         return (
           <NextLink key={`${idx} ${heading?.title}`} href={`#${heading?.headingId}`}>

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -126,7 +126,7 @@ const DocPage: NextPage<Props> = ({ frontmatter, content, navLinks, lastModified
                 </ReactMarkdown>
               </Stack>
 
-              <Stack display={{ base: 'none', xl: 'block' }} w={48}>
+              <Stack display={{ base: 'none', xl: 'block' }} w="clamp(var(--chakra-sizes-40), 12.5%, var(--chakra-sizes-56))">
                 <DocumentNav content={content} />
               </Stack>
             </Flex>

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -115,7 +115,7 @@ const DocPage: NextPage<Props> = ({ frontmatter, content, navLinks, lastModified
               </Text>
             </Stack>
 
-            <Flex width='100%' placeContent='space-between'>
+            <Flex width='100%' placeContent='space-between' gap={8}>
               <Stack maxW='768px'>
                 <ReactMarkdown
                   remarkPlugins={[gfm]}


### PR DESCRIPTION
## Description
- Adds a minimum gap between markdown content and the right nav on docs pages
- Shortens the divider in the right nav to prevent overflowing off right edge of screen

## Related issue
- [Fixes #77]