### PR TITLE
Prevent Header title from wrapping [Fixes #79]

### DIFF
--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -29,7 +29,7 @@ export const Header: FC = () => {
       >
         <NextLink href={'/'} passHref>
           <Link _hover={{ textDecoration: 'none' }}>
-            <Text textStyle='header-font'>go-ethereum</Text>
+            <Text textStyle='header-font' whiteSpace='nowrap'>go-ethereum</Text>
           </Link>
         </NextLink>
       </Stack>


### PR DESCRIPTION
## Description
- Adds `white-space: nowrap` to "go-ethereum" text in `Header` component

## Related issue
- [Fixes #79]