### PR TITLE
fix: show 2 latest releases for linux

### DIFF
--- a/src/components/UI/downloads/DownloadsTable.tsx
+++ b/src/components/UI/downloads/DownloadsTable.tsx
@@ -33,6 +33,8 @@ export const DownloadsTable: FC<Props> = ({
     androidData.length
   ];
 
+  const LAST_2_LINUX_RELEASES = amountOfReleasesToShow + 12;
+
   return (
     <Stack sx={{ mt: '0 !important' }} borderBottom='2px solid' borderColor='primary'>
       <Tabs variant='unstyled' onChange={idx => setTotalReleases(totalReleases[idx])}>
@@ -61,7 +63,7 @@ export const DownloadsTable: FC<Props> = ({
           <TabPanel p={0}>
             <DataTable
               columnHeaders={DOWNLOADS_TABLE_TAB_COLUMN_HEADERS}
-              data={linuxData.slice(0, amountOfReleasesToShow)}
+              data={linuxData.slice(0, LAST_2_LINUX_RELEASES)}
             />
           </TabPanel>
           <TabPanel p={0}>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,7 +20,7 @@ export const GETH_DISCORD_URL = 'https://discord.com/invite/nthXNEv';
 export const GO_URL = 'https://go.dev/';
 
 // Downloads
-export const DEFAULT_BUILD_AMOUNT_TO_SHOW = 10;
+export const DEFAULT_BUILD_AMOUNT_TO_SHOW = 12;
 export const DOWNLOAD_HEADER_BUTTONS: {
   [index: string]: {
     name: string;

--- a/src/pages/downloads.tsx
+++ b/src/pages/downloads.tsx
@@ -287,11 +287,11 @@ const DownloadsPage: NextPage<Props> = ({ data }) => {
   const [totalDevBuilds, setTotalDevBuilds] = useState(ALL_LINUX_DEV_BUILDS.length);
 
   const showMoreStableReleases = () => {
-    setAmountStableReleases(amountStableReleases + 10);
+    setAmountStableReleases(amountStableReleases + 12);
   };
 
   const showMoreDevBuilds = () => {
-    setAmountDevBuilds(amountDevBuilds + 10);
+    setAmountDevBuilds(amountDevBuilds + 12);
   };
 
   return (


### PR DESCRIPTION
This PR updates the default number of displayed rows to 12 and displays the 2 latest linux releases by default. Fixes #78 