### PR TITLE
Use long month formatting for last edit date [Fixes #86]

### DIFF
--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -63,7 +63,7 @@ export const getStaticProps: GetStaticProps = async context => {
       content,
       navLinks,
       lastModified: getParsedDate(lastModified.mtime, {
-        month: 'numeric',
+        month: 'long',
         day: 'numeric',
         year: 'numeric'
       })


### PR DESCRIPTION
## Description
Switch to using `long` for month formatting on last edit dates

## Screenshot
<img width="674" alt="image" src="https://user-images.githubusercontent.com/54227730/205471278-867876ef-c898-4c5f-95cd-8210b44a0a7d.png">

## Related issue
- [Fixes #86]

## Side note
We should consider capitalizing "Last edited" if we go with this approach, since the month will now be capitalized.... or lowercase the date as well.