### PR TITLE
Fix font size for OS label on mobile downloads [Fixes #94]

### DIFF
--- a/src/theme/foundations/textStyles.ts
+++ b/src/theme/foundations/textStyles.ts
@@ -137,7 +137,7 @@ export const textStyles = {
     fontWeight: 700,
     textTransform: 'uppercase',
     textAlign: 'center',
-    fontSize: 'sm'
+    fontSize: { base: 'xs', sm: 'sm' }
   },
   'docs-nav-dropdown': {
     fontFamily: 'heading',


### PR DESCRIPTION
## Description
- Reduces font size on downloads page for OS label on mobile devices less than `sm` cutoff (480px)

## Screenshot
<img width="413" alt="image" src="https://user-images.githubusercontent.com/54227730/205555358-ab6ec074-ce37-4969-b046-92dff3662afd.png">

## Preview link
pending

## Related issues
- [Fixes #94]