### PR TITLE
fix: Show older releases button width on mobile

### DIFF
--- a/src/pages/downloads.tsx
+++ b/src/pages/downloads.tsx
@@ -393,6 +393,7 @@ const DownloadsPage: NextPage<Props> = ({ data }) => {
                 <Stack
                   sx={{ mt: '0 !important' }}
                   borderLeft={{ base: 'none', md: '2px solid #11866f' }}
+                  w={{ base: '100%', md: 'auto' }}
                 >
                   <Link
                     as='button'
@@ -456,6 +457,7 @@ const DownloadsPage: NextPage<Props> = ({ data }) => {
                 <Stack
                   sx={{ mt: '0 !important' }}
                   borderLeft={{ base: 'none', md: '2px solid #11866f' }}
+                  w={{ base: '100%', md: 'auto' }}
                 >
                   <Link as='button' variant='button-link-secondary' onClick={showMoreDevBuilds}>
                     <Text


### PR DESCRIPTION
Fixes #99 