### PR TITLE
Docs: Bullet point lists rendering in green 

### DIFF
--- a/src/components/UI/docs/MDComponents.tsx
+++ b/src/components/UI/docs/MDComponents.tsx
@@ -143,7 +143,7 @@ const MDComponents = {
     );
   },
   li: ({ children }: any) => {
-    return <ListItem color='primary'>{children}</ListItem>;
+    return <ListItem>{children}</ListItem>;
   },
   note: ({ children }: any) => {
     return <Note>{children}</Note>;

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -116,7 +116,7 @@ const DocPage: NextPage<Props> = ({ frontmatter, content, navLinks, lastModified
             </Stack>
 
             <Flex width='100%' placeContent='space-between' gap={8}>
-              <Stack maxW='768px' sx={{ "*:first-child": { marginTop: '0 !important' } }}>
+              <Stack maxW='768px' sx={{ "*:first-of-type": { marginTop: '0 !important' } }}>
                 <ReactMarkdown
                   remarkPlugins={[gfm]}
                   rehypePlugins={[rehypeRaw]}


### PR DESCRIPTION
**Changes**
- Removed color from `li` elements
- Changed `first-child` to `first-of-type` based on console recommendation for SSR

Fixes: https://github.com/ethereum/geth-website/issues/81