### PR TITLE
[Logic bug] - Breadcrumbs contains header id 

### DIFF
--- a/src/components/UI/docs/Breadcrumbs.tsx
+++ b/src/components/UI/docs/Breadcrumbs.tsx
@@ -7,7 +7,8 @@ export const Breadcrumbs: FC = () => {
   const router = useRouter();
 
   let pathSplit = router.asPath.split('/');
-  pathSplit = pathSplit.splice(1, pathSplit.length);
+  pathSplit = pathSplit.splice(1, pathSplit.length)
+    .map((path) => path.includes('#') ? path.split('#')[0] : path);
 
   return (
     <>


### PR DESCRIPTION
**Changes**
- Remove anchor tag from paths in `Breadcrumb.tsx`

Fixes: https://github.com/ethereum/geth-website/issues/84