### PR TITLE
Adjust link styling for various states [Fixes #89]

### DIFF
--- a/src/theme/components/Link.ts
+++ b/src/theme/components/Link.ts
@@ -15,7 +15,7 @@ export const Link = {
     light: {
       textDecoration: 'underline',
       color: 'primary',
-      _hover: { color: 'body', textDecorationColor: 'primary' },
+      _hover: { color: 'body', textDecorationColor: 'secondary' },
       _focus: {
         color: 'primary',
         boxShadow: '0 0 0 1px var(--chakra-colors-primary) !important',

--- a/src/theme/components/Link.ts
+++ b/src/theme/components/Link.ts
@@ -15,13 +15,13 @@ export const Link = {
     light: {
       textDecoration: 'underline',
       color: 'primary',
-      _hover: { color: 'body', textDecorationColor: 'body' },
+      _hover: { color: 'body', textDecorationColor: 'primary' },
       _focus: {
         color: 'primary',
-        boxShadow: '0 0 0 1px var(--chakra-colors-primary)',
+        boxShadow: '0 0 0 1px var(--chakra-colors-primary) !important',
         textDecoration: 'none'
       },
-      _pressed: {
+      _active: {
         color: 'secondary',
         textDecorationColor: 'secondary'
       }


### PR DESCRIPTION
## Description
- Updates hover/active/focus link states to match design system

## Screenshot
PR:
<img width="610" alt="image" src="https://user-images.githubusercontent.com/54227730/205741996-224e616e-8604-48f5-b858-736ff360a948.png">

Figma:
<img width="386" alt="image" src="https://user-images.githubusercontent.com/54227730/205740981-5b10af04-632c-48e0-bad9-216fba7ac83e.png">

## Related issue
- [Closes #89]