### PR TITLE
fix: adds missing legacyBehavior prop [Fixes #98]

### DIFF
--- a/src/components/UI/ButtonLinkSecondary.tsx
+++ b/src/components/UI/ButtonLinkSecondary.tsx
@@ -18,7 +18,7 @@ export const ButtonLinkSecondary: React.FC<Props> = ({ href, children, ...restPr
           <Text textStyle='home-section-link-label'>{children}</Text>
         </Link>
       ) : (
-        <NextLink href={href.toString()} passHref {...restProps}>
+        <NextLink href={href.toString()} passHref legacyBehavior {...restProps}>
           <Link variant='button-link-secondary'>
             <Text textStyle='home-section-link-label'>{children}</Text>
           </Link>

--- a/src/components/UI/Header.tsx
+++ b/src/components/UI/Header.tsx
@@ -27,9 +27,11 @@ export const Header: FC = () => {
         borderColor='primary'
         flexGrow={2}
       >
-        <NextLink href={'/'} passHref>
+        <NextLink href={'/'} passHref legacyBehavior>
           <Link _hover={{ textDecoration: 'none' }}>
-            <Text textStyle='header-font' whiteSpace='nowrap'>go-ethereum</Text>
+            <Text textStyle='header-font' whiteSpace='nowrap'>
+              go-ethereum
+            </Text>
           </Link>
         </NextLink>
       </Stack>

--- a/src/components/UI/HeaderButtons.tsx
+++ b/src/components/UI/HeaderButtons.tsx
@@ -25,7 +25,7 @@ export const HeaderButtons: FC<Props> = ({ close }) => {
   return (
     <Flex direction={{ base: 'column', md: 'row' }}>
       {/* DOWNLOADS */}
-      <NextLink href={DOWNLOADS_PAGE} passHref>
+      <NextLink href={DOWNLOADS_PAGE} passHref legacyBehavior>
         <Link _hover={{ textDecoration: 'none' }} onClick={close}>
           <Stack {...menuItemStyles}>
             <Text textStyle={{ base: 'header-mobile-button', md: 'header-button' }}>downloads</Text>
@@ -34,7 +34,7 @@ export const HeaderButtons: FC<Props> = ({ close }) => {
       </NextLink>
 
       {/* DOCUMENTATION */}
-      <NextLink href={DOCS_PAGE} passHref>
+      <NextLink href={DOCS_PAGE} passHref legacyBehavior>
         <Link _hover={{ textDecoration: 'none' }} onClick={close}>
           <Stack {...menuItemStyles}>
             <Text textStyle={{ base: 'header-mobile-button', md: 'header-button' }}>

--- a/src/components/UI/docs/Breadcrumbs.tsx
+++ b/src/components/UI/docs/Breadcrumbs.tsx
@@ -16,7 +16,11 @@ export const Breadcrumbs: FC = () => {
           {pathSplit.map((path: string, idx: number) => {
             return (
               <BreadcrumbItem key={path}>
-                <NextLink href={`/${pathSplit.slice(0, idx + 1).join('/')}`} passHref>
+                <NextLink
+                  href={`/${pathSplit.slice(0, idx + 1).join('/')}`}
+                  passHref
+                  legacyBehavior
+                >
                   <BreadcrumbLink color={idx + 1 === pathSplit.length ? 'body' : 'primary'}>
                     {path}
                   </BreadcrumbLink>

--- a/src/components/UI/docs/DocsLinks.tsx
+++ b/src/components/UI/docs/DocsLinks.tsx
@@ -9,7 +9,7 @@ import {
   Stack,
   Text
 } from '@chakra-ui/react';
-import { AddIcon, MinusIcon } from '../svgs/'
+import { AddIcon, MinusIcon } from '../svgs/';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -27,7 +27,7 @@ export const DocsLinks: FC<Props> = ({ navLinks }) => {
   return (
     <Stack border='2px' borderColor='primary'>
       {navLinks.map(({ id, to, items }, idx) => {
-        const split = to?.split('/')
+        const split = to?.split('/');
         const isActive = slug && split && split[split.length - 1] === slug[slug.length - 1];
         return (
           <Accordion key={id} allowToggle mt='0 !important' defaultIndex={[0]}>
@@ -52,7 +52,7 @@ export const DocsLinks: FC<Props> = ({ navLinks }) => {
                       _groupHover={{ background: 'primary', color: 'bg', textDecoration: 'none' }}
                     >
                       {to ? (
-                        <NextLink href={to} passHref>
+                        <NextLink href={to} passHref legacyBehavior>
                           <Link textDecoration='none !important'>
                             <Text
                               textStyle='docs-nav-dropdown'
@@ -62,7 +62,7 @@ export const DocsLinks: FC<Props> = ({ navLinks }) => {
                                 verticalAlign: '-1.25px',
                                 marginInlineEnd: 2,
                                 fontSize: 'lg',
-                                display: isActive ? 'unset' : 'none',
+                                display: isActive ? 'unset' : 'none'
                               }}
                               _groupHover={{ color: 'bg' }}
                             >
@@ -100,4 +100,4 @@ export const DocsLinks: FC<Props> = ({ navLinks }) => {
       })}
     </Stack>
   );
-}
+};

--- a/src/components/UI/docs/DocumentNav.tsx
+++ b/src/components/UI/docs/DocumentNav.tsx
@@ -27,7 +27,7 @@ export const DocumentNav: FC<Props> = ({ content }) => {
       <Divider borderColor='primary' my={`4 !important`} />
       {parsedHeadings.map((heading, idx) => {
         return (
-          <NextLink key={`${idx} ${heading?.title}`} href={`#${heading?.headingId}`}>
+          <NextLink key={`${idx} ${heading?.title}`} href={`#${heading?.headingId}`} legacyBehavior>
             <Link m={0} textDecoration='none !important'>
               <Text
                 color={activeHash === heading?.headingId ? 'body' : 'primary'}
@@ -36,19 +36,19 @@ export const DocumentNav: FC<Props> = ({ content }) => {
                 _hover={{
                   background: 'primary',
                   boxShadow: '0 0 0 6px var(--chakra-colors-primary)',
-                  color: 'bg',
+                  color: 'bg'
                 }}
                 _focus={{
                   background: 'primary',
                   boxShadow: '0 0 0 6px var(--chakra-colors-primary) !important',
                   color: 'bg',
                   outline: '2px solid var(--chakra-colors-secondary) !important',
-                  outlineOffset: '4px',
+                  outlineOffset: '4px'
                 }}
                 _active={{
                   background: 'secondary',
                   boxShadow: '0 0 0 6px var(--chakra-colors-secondary)',
-                  color: 'bg',
+                  color: 'bg'
                 }}
               >
                 {heading?.title}

--- a/src/components/UI/docs/LinksList.tsx
+++ b/src/components/UI/docs/LinksList.tsx
@@ -15,11 +15,16 @@ export const LinksList: FC<LinksListProps> = ({ links }) => {
   return (
     <Stack px={4}>
       {links.map(({ id, to, items }) => {
-        const split = to?.split('/')
+        const split = to?.split('/');
         const isActive = slug && split && split[split.length - 1] === slug[slug.length - 1];
         return to ? (
-          <Stack key={id} pb={items ? 6 : 0} _hover={{ background: 'primary', color: 'bg' }} data-group>
-            <NextLink href={to} passHref key={id}>
+          <Stack
+            key={id}
+            pb={items ? 6 : 0}
+            _hover={{ background: 'primary', color: 'bg' }}
+            data-group
+          >
+            <NextLink href={to} passHref key={id} legacyBehavior>
               <Link textDecoration='none !important'>
                 <Text
                   textStyle='docs-nav-links'
@@ -29,12 +34,11 @@ export const LinksList: FC<LinksListProps> = ({ links }) => {
                     verticalAlign: '-1.25px',
                     marginInlineEnd: 2,
                     fontSize: 'lg',
-                    display: isActive ? 'unset' : 'none',
+                    display: isActive ? 'unset' : 'none'
                   }}
                   _groupHover={{
                     color: 'bg',
-                    boxShadow: '0 0 0 var(--chakra-space-2) var(--chakra-colors-primary)',
-                    
+                    boxShadow: '0 0 0 var(--chakra-space-2) var(--chakra-colors-primary)'
                   }}
                 >
                   {id}

--- a/src/components/UI/docs/MDComponents.tsx
+++ b/src/components/UI/docs/MDComponents.tsx
@@ -35,14 +35,14 @@ const MDComponents = {
         {children}
       </Link>
     ) : (
-      <NextLink href={href} passHref>
+      <NextLink href={href} passHref legacyBehavior>
         <Link variant='light'>{children}</Link>
       </NextLink>
     );
   },
   // headings
   h1: ({ children }: any) => {
-    const { children: parsedChildren, headingId} = parseHeadingId(children);
+    const { children: parsedChildren, headingId } = parseHeadingId(children);
 
     return (
       <Heading as='h1' textAlign='start' mb='5 !important' {...header1} id={headingId}>
@@ -51,16 +51,23 @@ const MDComponents = {
     );
   },
   h2: ({ children }: any) => {
-    const { children: parsedChildren, headingId} = parseHeadingId(children);
+    const { children: parsedChildren, headingId } = parseHeadingId(children);
 
     return (
-      <Heading as='h2' textAlign='start' mt={{ base: '12 !important' , md: '16 !important'}} mb='4 !important' {...header2} id={headingId}>
+      <Heading
+        as='h2'
+        textAlign='start'
+        mt={{ base: '12 !important', md: '16 !important' }}
+        mb='4 !important'
+        {...header2}
+        id={headingId}
+      >
         {parsedChildren}
       </Heading>
     );
   },
   h3: ({ children }: any) => {
-    const { children: parsedChildren, headingId} = parseHeadingId(children);
+    const { children: parsedChildren, headingId } = parseHeadingId(children);
     return (
       <Heading as='h3' mt='5 !important' mb='2.5 !important' {...header3} id={headingId}>
         {parsedChildren}
@@ -68,7 +75,7 @@ const MDComponents = {
     );
   },
   h4: ({ children }: any) => {
-    const { children: parsedChildren, headingId} = parseHeadingId(children);
+    const { children: parsedChildren, headingId } = parseHeadingId(children);
 
     return (
       <Heading as='h4' mb='2.5 !important' {...header4} id={headingId}>

--- a/src/components/UI/downloads/DownloadsHero.tsx
+++ b/src/components/UI/downloads/DownloadsHero.tsx
@@ -81,7 +81,7 @@ export const DownloadsHero: FC<DownloadsHero> = ({
           {Object.keys(DOWNLOAD_HEADER_BUTTONS).map((key: string) => {
             const { name, buildURL, Svg, ariaLabel } = DOWNLOAD_HEADER_BUTTONS[key];
             return (
-              <NextLink key={key} href={buildURL} passHref>
+              <NextLink key={key} href={buildURL} passHref legacyBehavior>
                 <Button as='a' variant='downloadsHeader' width={{ base: '100%' }} h={16}>
                   <HStack spacing={4}>
                     <Stack alignItems='center'>

--- a/src/components/UI/homepage/HomeHero.tsx
+++ b/src/components/UI/homepage/HomeHero.tsx
@@ -36,7 +36,7 @@ export const HomeHero: FC = () => {
         alignItems={{ base: 'center', md: 'flex-start' }}
       >
         <Flex direction='column' alignItems='center' mr={{ md: 6 }}>
-          <NextLink href={DOWNLOADS_PAGE} passHref>
+          <NextLink href={DOWNLOADS_PAGE} passHref legacyBehavior>
             <Button variant='primary' as='a' mb={1}>
               <Text textStyle='homepage-primary-label'>Download</Text>
             </Button>
@@ -48,7 +48,7 @@ export const HomeHero: FC = () => {
         </Flex>
 
         <Flex direction='column' alignItems='center'>
-          <NextLink href={DOCS_PAGE} passHref>
+          <NextLink href={DOCS_PAGE} passHref legacyBehavior>
             <Button variant='primary' as='a' mb={1}>
               <Text textStyle='homepage-primary-label'>Documentation</Text>
             </Button>

--- a/src/components/UI/homepage/QuickLinks.tsx
+++ b/src/components/UI/homepage/QuickLinks.tsx
@@ -28,7 +28,7 @@ export const QuickLinks: FC = () => {
           </Stack>
         </GridItem>
         <GridItem borderBottom='2px solid' borderColor='primary'>
-          <NextLink href={`${DOCS_PAGE}/getting-started`} passHref>
+          <NextLink href={`${DOCS_PAGE}/getting-started`} passHref legacyBehavior>
             <Link _hover={{ textDecoration: 'none' }}>
               <Stack
                 data-group
@@ -66,7 +66,7 @@ export const QuickLinks: FC = () => {
           </Stack>
         </GridItem>
         <GridItem borderBottom='2px solid' borderColor='primary'>
-          <NextLink href={FAQ_PAGE} passHref>
+          <NextLink href={FAQ_PAGE} passHref legacyBehavior>
             <Link _hover={{ textDecoration: 'none' }}>
               <Stack
                 data-group
@@ -104,7 +104,7 @@ export const QuickLinks: FC = () => {
           </Stack>
         </GridItem>
         <GridItem>
-          <NextLink href={CONTRIBUTING_PAGE} passHref>
+          <NextLink href={CONTRIBUTING_PAGE} passHref legacyBehavior>
             <Link _hover={{ textDecoration: 'none' }}>
               <Stack
                 data-group

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -43,7 +43,7 @@ export const Footer: FC = () => {
             borderColor='primary'
             p={4}
           >
-            <NextLink href={DOWNLOADS_PAGE} passHref>
+            <NextLink href={DOWNLOADS_PAGE} passHref legacyBehavior>
               <Link _hover={{ textDecoration: 'none' }}>
                 <Text textStyle='footer-link-label'>DOWNLOADS</Text>
               </Link>
@@ -61,7 +61,7 @@ export const Footer: FC = () => {
             borderColor='primary'
             p={4}
           >
-            <NextLink href={DOCS_PAGE} passHref>
+            <NextLink href={DOCS_PAGE} passHref legacyBehavior>
               <Link _hover={{ textDecoration: 'none' }}>
                 <Text textStyle='footer-link-label'>DOCUMENTATION</Text>
               </Link>


### PR DESCRIPTION
This PR adds the [missing `legacyBehavior` prop](https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-tag) on `NextLink` components that wrap a Chakra `Link`, to fix the nested `<a>` warning/issue 