### PR TITLE
[docs] LHS menu should be closed by default

### DIFF
--- a/src/components/UI/docs/DocsLinks.tsx
+++ b/src/components/UI/docs/DocsLinks.tsx
@@ -30,7 +30,7 @@ export const DocsLinks: FC<Props> = ({ navLinks }) => {
         const split = to?.split('/');
         const isActive = slug && split && split[split.length - 1] === slug[slug.length - 1];
         return (
-          <Accordion key={id} allowToggle mt='0 !important' defaultIndex={[0]}>
+          <Accordion key={id} allowToggle mt='0 !important'>
             <AccordionItem border='none'>
               {({ isExpanded }) => (
                 <>


### PR DESCRIPTION
**Changes**
- Remove defaultIndex from Accordion to have them default closed in `DocsLinks.tsx`

Fixes: https://github.com/ethereum/geth-website/issues/97