### PR TITLE
Fix double slash in url

### DIFF
--- a/docs/interacting-with-geth/rpc/ns-debug.md
+++ b/docs/interacting-with-geth/rpc/ns-debug.md
@@ -672,7 +672,7 @@ If set, the previous four arguments will be ignored.
   Valid values are described [here](https://golang.org/pkg/time/#ParseDuration).
 - `tracerConfig`: Config for the specified `tracer`. For example see callTracer's [config](/docs/developers/evm-tracing/built-in-tracers#config).
 
-Geth comes with a bundle of [built-in tracers](/docs/developers/evm-tracing//built-in-tracers), each providing various data about a transaction. This method defaults to the [struct logger](/docs/developers/evm-tracing/built-in-tracers#structopcode-logger). The `tracer` field of the second parameter can be set to use any of the other tracers. Alternatively a [custom tracer](/docs/developers/evm-tracing/custom-tracer) can be implemented in either Go or Javascript.
+Geth comes with a bundle of [built-in tracers](/docs/developers/evm-tracing/built-in-tracers), each providing various data about a transaction. This method defaults to the [struct logger](/docs/developers/evm-tracing/built-in-tracers#structopcode-logger). The `tracer` field of the second parameter can be set to use any of the other tracers. Alternatively a [custom tracer](/docs/developers/evm-tracing/custom-tracer) can be implemented in either Go or Javascript.
 
 #### Example
 


### PR DESCRIPTION
## Description
- Removes double slash causing Netlify build errors

## Related issue
<img width="916" alt="image" src="https://user-images.githubusercontent.com/54227730/206800576-2e753860-0de4-4cf0-92b1-adc3296be356.png">
