### PR TITLE
Add default tab on downloads page based on user OS

### DIFF
--- a/src/components/UI/downloads/DownloadsTable.tsx
+++ b/src/components/UI/downloads/DownloadsTable.tsx
@@ -39,11 +39,10 @@ export const DownloadsTable: FC<Props> = ({
 
   const getDefaultIndex = useMemo<number>(() => {
     const OS: string = typeof window !== 'undefined' ? window.navigator.platform : '';
-    const userAgent = typeof window !== 'undefined' ? window.navigator.userAgent : '';
-    if (OS.includes('Mac')) return 1;
-    if (OS.includes('Win')) return 2;
-    if (OS.includes('iPhone')) return 3;
-    if (/Android/i.test(OS) || /Android|SamsungBrowser/i.test(userAgent)) return 4;
+    if (/Mac/i.test(OS)) return 1;
+    if (/Win/i.test(OS)) return 2;
+    if (/iPhone/i.test(OS)) return 3;
+    if (/Android/i.test(OS)) return 4;
     return 0;
   }, [])
 

--- a/src/components/UI/downloads/DownloadsTable.tsx
+++ b/src/components/UI/downloads/DownloadsTable.tsx
@@ -39,10 +39,11 @@ export const DownloadsTable: FC<Props> = ({
 
   const getDefaultIndex = useMemo<number>(() => {
     const OS: string = typeof window !== 'undefined' ? window.navigator.platform : '';
+    const userAgent = typeof window !== 'undefined' ? window.navigator.userAgent : '';
     if (OS.includes('Mac')) return 1;
     if (OS.includes('Win')) return 2;
     if (OS.includes('iPhone')) return 3;
-    if (OS.includes('Android')) return 4;
+    if (OS.includes('Android') || userAgent.includes("SamsungBrowser")) return 4;
     return 0;
   }, [])
 

--- a/src/components/UI/downloads/DownloadsTable.tsx
+++ b/src/components/UI/downloads/DownloadsTable.tsx
@@ -39,10 +39,11 @@ export const DownloadsTable: FC<Props> = ({
 
   const getDefaultIndex = useMemo<number>(() => {
     const OS: string = typeof window !== 'undefined' ? window.navigator.platform : '';
+    const userAgent = typeof window !== 'undefined' ? window.navigator.userAgent : '';
     if (/Mac/i.test(OS)) return 1;
     if (/Win/i.test(OS)) return 2;
     if (/iPhone/i.test(OS)) return 3;
-    if (/Android/i.test(OS)) return 4;
+    if (/Android/i.test(userAgent)) return 4;
     return 0;
   }, [])
 

--- a/src/components/UI/downloads/DownloadsTable.tsx
+++ b/src/components/UI/downloads/DownloadsTable.tsx
@@ -1,5 +1,5 @@
 import { Stack, Tabs, TabList, Tab, Text, TabPanel, TabPanels } from '@chakra-ui/react';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 
 import { DataTable } from '../../UI';
 
@@ -37,6 +37,15 @@ export const DownloadsTable: FC<Props> = ({
 
   const LAST_2_LINUX_RELEASES = amountOfReleasesToShow + 12;
 
+  const getDefaultIndex = useMemo<number>(() => {
+    const OS: string = typeof window !== 'undefined' ? window.navigator.platform : '';
+    if (OS.includes('Mac')) return 1;
+    if (OS.includes('Win')) return 2;
+    if (OS.includes('iPhone')) return 3;
+    if (OS.includes('Android')) return 4;
+    return 0;
+  }, [])
+
   return (
     <Stack
       sx={{ mt: '0 !important' }}
@@ -46,7 +55,7 @@ export const DownloadsTable: FC<Props> = ({
           : 'none'
       }
     >
-      <Tabs variant='unstyled' onChange={idx => setTotalReleases(totalReleases[idx])}>
+      <Tabs variant='unstyled' onChange={idx => setTotalReleases(totalReleases[idx])} defaultIndex={getDefaultIndex}>
         <TabList color='primary' bg='button-bg'>
           {DOWNLOADS_TABLE_TABS.map((tab, idx) => {
             return (

--- a/src/components/UI/downloads/DownloadsTable.tsx
+++ b/src/components/UI/downloads/DownloadsTable.tsx
@@ -43,7 +43,7 @@ export const DownloadsTable: FC<Props> = ({
     if (OS.includes('Mac')) return 1;
     if (OS.includes('Win')) return 2;
     if (OS.includes('iPhone')) return 3;
-    if (OS.includes('Android') || userAgent.includes("SamsungBrowser")) return 4;
+    if (/Android/i.test(OS) || /Android|SamsungBrowser/i.test(userAgent)) return 4;
     return 0;
   }, [])
 


### PR DESCRIPTION
## Description
- Checks the users operating system and sets this as the default tab when navigating to the downloads page.

## Preview link
https://deploy-preview-167--melodious-puffpuff-8e1109.netlify.app/downloads