### PR TITLE
Redirects update [Fixes #159]

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -51,7 +51,7 @@ const redirects = [
   },
   {
     source: '/docs/interface/private-network',
-    destination: '/docs/developers/geth-developer/private-network',
+    destination: '/docs/fundamentals/private-network',
     permanent: true
   },
   {

--- a/redirects.js
+++ b/redirects.js
@@ -1,5 +1,10 @@
 const redirects = [
   {
+    source: '/getting-started/dev-mode',
+    destination: '/docs/developers/geth-developer/dev-mode',
+    permanent: true
+  },
+  {
     source: '/docs/getting-started/dev-mode',
     destination: '/docs/developers/geth-developer/dev-mode',
     permanent: true
@@ -47,6 +52,11 @@ const redirects = [
   {
     source: '/docs/interface/javascript-console',
     destination: '/docs/interacting-with-geth/javascript-console',
+    permanent: true
+  },
+  {
+    source: '/getting-started/private-network',
+    destination: '/docs/fundamentals/private-network',
     permanent: true
   },
   {


### PR DESCRIPTION
## Description
- Updates redirect for `/private-network` path after #169 changes introduced
- Adds legacy directs noted in issue #159

## Related issue
- [Fixes #159]