### PR TITLE
Breadcrumbs on /docs/ page when the URL has a header ID

### DIFF
--- a/src/components/UI/docs/Breadcrumbs.tsx
+++ b/src/components/UI/docs/Breadcrumbs.tsx
@@ -11,7 +11,7 @@ export const Breadcrumbs: FC = () => {
 
   return (
     <>
-      {router.asPath !== '/docs' ? (
+      {router.asPath !== '/docs' && pathSplit.length > 1? (
         <Breadcrumb>
           {pathSplit.map((path: string, idx: number) => {
             return (


### PR DESCRIPTION
- Fix bug where Breadcrumbs rendering on root /docs page when a header ID is present

Fixes: https://github.com/ethereum/geth-website/issues/179