### PR TITLE
Footer sticky bottom

### DIFF
--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -20,7 +20,7 @@ const hoverStyles = {
 
 export const Footer: FC = () => {
   return (
-    <Flex mt={{ base: 4, lg: 8 }} direction={{ base: 'column', lg: 'row' }}>
+    <Flex mt={{ base: 4, lg: 8 }} direction={{ base: 'column', lg: 'row' }} position='sticky' top='100%'>
       <Flex
         direction={{ base: 'column', md: 'row' }}
         justifyContent={{ md: 'space-between' }}

--- a/src/components/layouts/Layout.tsx
+++ b/src/components/layouts/Layout.tsx
@@ -12,7 +12,12 @@ interface Props {
 
 export const Layout: FC<Props> = ({ children }) => {
   return (
-    <Container maxW={{ base: 'full', md: 'container.2xl' }} my={{ base: 4, md: 7 }}>
+    <Container
+      maxW={{ base: 'full', md: 'container.2xl' }}
+      my={{ base: 4, md: 7 }}
+      h='calc(100vh - 2 * var(--chakra-space-7))'
+      position='relative'
+    >
       <Header />
 
       {children}


### PR DESCRIPTION
## Description
- Adds full height and relative positioning to parent layout component
- Makes footer sticky to the bottom

## Screenshot
<img width="753" alt="image" src="https://user-images.githubusercontent.com/54227730/208187324-38ca224b-660e-419c-9c2e-a1006180080e.png">

## Related issue
- [Fixes ethereum/go-ethereum#26425]