### PR TITLE
Fix hash-link bug with left docs nav

### DIFF
--- a/src/components/UI/docs/DocsLinks.tsx
+++ b/src/components/UI/docs/DocsLinks.tsx
@@ -35,7 +35,7 @@ export const DocsLinks: FC<Props> = ({ navLinks, toggleMobileAccordion }) => {
       navLinks.reduce(
         (acc, navLink) => ({
           ...acc,
-          [navLink.id]: checkNavLinks({ items: navLink.items, pathCheck: asPath })
+          [navLink.id]: checkNavLinks({ items: navLink.items, pathCheck: asPath.split('#')[0] })
         }),
         {}
       )


### PR DESCRIPTION
Links that contain hash links at the end were not matching to properly open the correct left nav section in the docs.

This patches the link checked to remove this hash link before checking for a match.