### PR TITLE
Add missing redirect

### DIFF
--- a/docs/developers/geth-developer/dev-guide.md
+++ b/docs/developers/geth-developer/dev-guide.md
@@ -6,7 +6,7 @@ description: Entry point for developers working on Geth
 This document is the entry point for developers who wish to work on Geth. Developers are people who are interested to build, develop, debug, submit
 a bug report or pull request or otherwise contribute to the Geth source code.
 
-Please see [Contributing](/docs/developers/contributing) for the Geth contribution guidelines.
+Please see [Contributing](/docs/developers/geth-developer/contributing) for the Geth contribution guidelines.
 
 ## Building and Testing {#building-and-testing}
 

--- a/redirects.js
+++ b/redirects.js
@@ -283,6 +283,11 @@ const redirects = [
     source: '/docs/tools/clef',
     destination: '/docs/tools/clef/introduction',
     permanent: true
+  },
+  {
+    source: '/docs/developers/contributing',
+    destination: '/docs/developers/geth-developer/contributing',
+    permanent: true
   }
 ];
 

--- a/src/data/documentation-links.yaml
+++ b/src/data/documentation-links.yaml
@@ -111,7 +111,7 @@
         - id: Code review guidelines
           to: /docs/developers/geth-developer/code-review-guidelines
     - id: Contributing
-      to: /docs/developers/contributing
+      to: /docs/developers/geth-developer/contributing
 - id: Monitoring
   items:
     - id: Dashboards


### PR DESCRIPTION
Fixes redirect to /docs/developers/geth-developer/contributing from /docs/developers/contributing